### PR TITLE
Updated link to original article

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Masonry gallery based on ReactJS component.
 
 All the credit for [@dudleystorey](https://twitter.com/dudleystorey) for his black magic post about flex ratios:
 
-http://demosthenes.info/blog/929/Modern-Masonry-with-Flexbox-and-JavaScript
+http://thenewcode.com/929/Modern-Masonry-with-Flexbox-and-JavaScript
 
 ## Instalation
 Clone this repository and run:


### PR DESCRIPTION
The link to the article referenced in the readme is dead

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carlosvillu/react-masonry-gallery/4)
<!-- Reviewable:end -->
